### PR TITLE
Manual merge from old Akujin/Emergence plus new changes made to the main branch for namespaces

### DIFF
--- a/php-bootstrap/lib/Debug.class.php
+++ b/php-bootstrap/lib/Debug.class.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Emergence;
+
 class Debug
 {
 	static public $log = array();

--- a/php-bootstrap/lib/Emergence.class.php
+++ b/php-bootstrap/lib/Emergence.class.php
@@ -1,4 +1,5 @@
 <?php
+namespace Emergence;
 
 class Emergence
 {	

--- a/php-bootstrap/lib/EmergenceIO.class.php
+++ b/php-bootstrap/lib/EmergenceIO.class.php
@@ -1,4 +1,6 @@
 <?php
+namespace Emergence;
+
 class EmergenceIO {
 	
 	/*	function export	
@@ -93,6 +95,13 @@ class EmergenceIO {
 					while (!feof($fp)) {
 					    $contents .= fread($fp, 2);
 					}
+                    if(php_sapi_name() == "cli")
+                    {
+                        $pathinfo = pathinfo($file['name']);
+                        
+                        echo sprintf("\033[KImporting %s . . . %s%%\t %s\r",$inputFile,number_format(($i / $zip->numFiles) * 100,2),$pathinfo['filename']);
+                    }
+                    
 					SiteCollection::createFile($targetDirectory.$file['name'],$contents);
 					fclose($fp);
 					$i++;
@@ -101,6 +110,11 @@ class EmergenceIO {
 			default:
 				throw new Exception('MIME type ' . $type . ' unsupported.');
 		}
+        
+        if(php_sapi_name() == "cli")
+        {
+            echo "\033[KImport complete.\n";
+        }
 
 	}
 	

--- a/php-bootstrap/lib/File.class.php
+++ b/php-bootstrap/lib/File.class.php
@@ -1,4 +1,5 @@
 <?php
+namespace Emergence;
 
 class File
 {

--- a/php-bootstrap/lib/SiteCollection.class.php
+++ b/php-bootstrap/lib/SiteCollection.class.php
@@ -1,11 +1,11 @@
 <?php
-
+namespace Emergence;
 
 class SiteCollection
 {
 	static public $tableName = '_e_file_collections';
 	static public $autoCreate = false;
-	static public $fileClass = 'SiteFile';
+	static public $fileClass = 'Emergence\\SiteFile';
 
 	public $_handle;
 	public $_record;
@@ -75,7 +75,7 @@ class SiteCollection
 			debug_print_backtrace();
 			die('SiteID must be converted to (bool)$remote');
 		}
-		
+
 		$where[] = sprintf('Handle = "%s"', DB::escape($handle));
 		
 		if(!$includeDeleted)
@@ -145,7 +145,7 @@ class SiteCollection
 				,$this->ID
 			)
 		);
-		
+
 		while($record = $collectionResults->fetch_assoc())
 		{
 			$children[] = new static($record['Handle'], $record);
@@ -374,10 +374,10 @@ class SiteCollection
 			//printf("getting after creating %s in %u->%s<br>", $handle, $parentCollection ? $parentCollection->ID : null, $siteID);
 			$collection = static::getByHandle($handle, $parentCollection ? $parentCollection->ID : null, $remote);
 		}
-		
+
 		if($parentCollection && !$collection->_parent)
 			$collection->_parent = $parentCollection;
-	
+
 		return $collection;
 	}
 	

--- a/php-bootstrap/tools/erase.php
+++ b/php-bootstrap/tools/erase.php
@@ -1,0 +1,27 @@
+<?php
+ini_set('error_reporting',E_ALL & ~E_NOTICE & ~E_STRICT);  
+
+set_include_path(get_include_path() . PATH_SEPARATOR . '/var/emergence/kernel/'); 
+
+require('lib/Emergence.class.php');
+require('lib/Debug.class.php');
+require('lib/DB.class.php');
+require('lib/File.class.php');
+require('lib/Site.class.php');
+require('lib/SiteCollection.class.php');
+require('lib/SiteFile.class.php');
+require('lib/EmergenceIO.class.php');
+
+include('Site.config.php');
+
+Site::$rootPath = '/var/emergence/sites/skeleton';
+
+DB::nonQuery('TRUNCATE `_e_files`;');
+DB::nonQuery('TRUNCATE `_e_file_collections`;');
+
+$data = scandir(Site::$rootPath . '/data');
+foreach($data as $file)
+{
+    if($file == '.' || $file == '..') { continue; }
+    unlink(Site::$rootPath . '/data/' . $file); 
+}

--- a/php-bootstrap/tools/import.php
+++ b/php-bootstrap/tools/import.php
@@ -1,0 +1,27 @@
+<?php
+ini_set('error_reporting',E_ALL & ~E_NOTICE & ~E_STRICT);
+ini_set('memory_limit', '512M');
+
+set_include_path(get_include_path() . PATH_SEPARATOR . '/var/emergence/kernel/');
+
+require('lib/Emergence.class.php');
+require('lib/Debug.class.php');
+require('lib/DB.class.php');
+require('lib/File.class.php');
+require('lib/Site.class.php');
+require('lib/SiteCollection.class.php');
+require('lib/SiteFile.class.php');
+require('lib/EmergenceIO.class.php');
+
+include('Site.config.php');
+
+Site::$rootPath = '/var/emergence/sites/skeleton';
+
+$_SERVER['HTTP_HOST'] = Site::$config['primary_hostname'];
+
+EmergenceIO::import($argv[1]);
+
+$User = DB::oneValue("SELECT `ID` FROM `people` WHERE `AccountLevel`='Developer'");
+
+DB::nonQuery("UPDATE `_e_files` SET `AuthorID`='{$User}' WHERE `AuthorID` IS NULL;");
+DB::nonQuery("UPDATE `_e_file_collections` SET `CreatorID`='{$User}' WHERE `CreatorID`=0;");


### PR DESCRIPTION
-Includes a tool to import zip into the Emergence file system for an
empty site from CLI
-Includes a tool to erase a site's Emergence file system from CLI
-Added a custom error handler option for most DB functions to allow
custom handling for SQL errors. This allows features like automatic
table creation by ActiveRecord if a table is not found.
-New Emergence namespace for all classes
-EmergenceIO class now automatically detects if it's running in a CLI
and will write progress to CLI.
-PSR-0 autoloader support for the class loader in Site class.
-SiteFile will now throw better errors when Site::$rootPath is not
writable.
