### PR TITLE
Added the mysqld detection for the CentOS distribution

### DIFF
--- a/bin/kernel
+++ b/bin/kernel
@@ -93,11 +93,11 @@ else
 	// detect mysqld in CentOS		
     else if(fs.existsSync('/usr/libexec/mysqld'))
         CONFIG.services.plugins.sql = {
-                type: 'mysql'
-                ,autoStart: true
-                ,execPath: '/usr/libexec/mysqld'
-                ,managerUser: 'root'
-                ,managerPassword: sitesLib.generatePassword()
+            type: 'mysql'
+            ,autoStart: true
+            ,execPath: '/usr/libexec/mysqld'
+            ,managerUser: 'root'
+            ,managerPassword: sitesLib.generatePassword()
         };
 	
 	// detect php-fpm

--- a/bin/kernel
+++ b/bin/kernel
@@ -89,15 +89,16 @@ else
 			,managerUser: 'root'
 			,managerPassword: sitesLib.generatePassword()
 		};
-	else if(fs.existsSync('/usr/bin/mysqld_safe'))
-		CONFIG.services.plugins.sql = {
-			type: 'mysql'
-			,autoStart: true
-			,execPath: '/usr/bin/mysqld_safe'
-			,managerUser: 'root'
-			,managerPassword: sitesLib.generatePassword()
-		};
 	
+	// detect mysqld in CentOS		
+    else if(fs.existsSync('/usr/libexec/mysqld'))
+        CONFIG.services.plugins.sql = {
+                type: 'mysql'
+                ,autoStart: true
+                ,execPath: '/usr/libexec/mysqld'
+                ,managerUser: 'root'
+                ,managerPassword: sitesLib.generatePassword()
+        };
 	
 	// detect php-fpm
 	if(fs.existsSync('/usr/bin/php-fpm'))


### PR DESCRIPTION
Hey Chris I found the **mysqld** bin at `/usr/libexec/mysqld` in the CentOS distribution.  I updated the kernel file and it appears to be functioning. Give the change a once over before you merge my pull request

thx

-a
