### PR TITLE
Improved Error Handling: VFS paths and Edit Links

### DIFF
--- a/php-bootstrap/lib/Site.class.php
+++ b/php-bootstrap/lib/Site.class.php
@@ -393,9 +393,9 @@ class Site
             $vfsPath = isset($pathCache[$id]) ? $pathCache[$id] : $pathCache[$id] = implode('/', SiteFile::getByID($id)->getFullPath());
 
             if ($linkify) {
-                return '<a href="/develop#/' . $vfsPath . '" target="_blank">' . $vfsPath . '</a>';
+                return '<a href="/develop#/' . $vfsPath . '" target="_blank">' . $vfsPath . '</a> (' . $matches[0] . ')';
             } else {
-                return $vfsPath . ' (' . explode('', $matches) . ')';
+                return $vfsPath . ' (' . $matches[0] . ')';
             }
         }, $str);
     }

--- a/php-bootstrap/lib/Site.class.php
+++ b/php-bootstrap/lib/Site.class.php
@@ -477,17 +477,20 @@ class Site
             // TODO: If the file is in the EMERGENCE_BOOTSTRAP_DIR or the DAV location, link the user to documentation on how to repair core Emergence files
 
             $SiteFile = SiteFile::getByID(substr($filePath, strrpos($filePath, '/') + 1));
-            $fileContents = file($SiteFile->getRealPath());
             $vfsPath = implode('/', $SiteFile->getFullPath());
 
             // For non-developers, create an exception based on the fatal error and pass it to handleException
             if (!UserSession::getFromRequest()->hasAccountLevel('Developer')) {
                 ob_clean();
                 self::handleException(new Exception('Fatal Error: ' . $lastError['message'] . ' in ' . $vfsPath . ' on line ' . $lastError['line'], $lastError['type']), false);
+            } else {
+                $fileContents = file($SiteFile->getRealPath());
+                $fileContents[$lastError['line']-1] = rtrim($fileContents[$lastError['line']-1]) . ' //' . $lastError['message'];
             }
 
             $outputBuffer = str_replace($filePath, $vfsPath, ob_get_clean());
-            printf('<button><a href="/develop#/%s" target="_blank">Open %1$s with Emergence Editor</a></button><br><hr>', $vfsPath);
+            printf('<button><a href="/develop#/%s" target="_blank">Open %1$s in Emergence Editor</a></button><br><hr>', $vfsPath);
+            highlight_string(implode("\n", $fileContents));
             print $outputBuffer;
 
             if (!headers_sent()) {


### PR DESCRIPTION
**Non-Public Wrike ticket:** https://www.wrike.com/open.htm?id=46377903

This pull request replaces "real paths" anywhere in an error handler/trace with the VFS path.

**If the user is logged in as a developer, the path will be linkified to open that file in the Emergence Editor in a new window.**
# Developer encounters an exception/error

![Screenshot 1](http://i.imgur.com/QTNNs3h.png)

Additionally, this now traps fatal errors, outputting the source annotated a comment containing the error string on the line where the error occurred. This also includes a button to open that file in the Emergence Editor.
# Developer encounters fatal error

![Screenshot 2](http://i.imgur.com/wYACSmI.png)
In the future, when documented, we can link to a **"How to recover core files without using the Emergence Editor"**
# Normal user encounters fatal error (debug=true)

![Screenshot 3](http://i.imgur.com/SBb2x8q.png)
