### PR TITLE
Node 4.x Compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"mysql": "0.9.x",
 		"node-static": "0.6.x",
 		"http-auth": "1.2.7",
-		"posix": "*"
+		"posix": "JarvusInnovations/node-posix#master"
 	},
 	"bin": {
 		"emergence-kernel": "./bin/kernel",


### PR DESCRIPTION
@robey has a PR in for node-posix that fixes the compatibility issues, however, it was not merged.

I forked his repo under JarvusInnovations and pointed the package.json to grab that in the meantime.