### PR TITLE
DB::foundRows detect table not found error

### DIFF
--- a/php-bootstrap/lib/DB.class.php
+++ b/php-bootstrap/lib/DB.class.php
@@ -35,6 +35,11 @@ class DB
 
     public static function foundRows()
     {
+        // table not found
+        if (self::getMysqli()->sqlstate == '42S02') {
+            return 0;
+        }
+
         return (int)self::oneValue('SELECT FOUND_ROWS()');
     }
 


### PR DESCRIPTION
Update looks for a table not found error and returns 0 if the table isn't found. Without this if the table doesn't exist the total rows returns 1 instead of 0.
