### PR TITLE
Add cache clearing endpoint to sites

### DIFF
--- a/kernel-lib/services/php-fpm.js
+++ b/kernel-lib/services/php-fpm.js
@@ -46,6 +46,9 @@ exports.PhpFpmService = function(name, controller, options) {
 
     // listen for site updated
     controller.sites.on('siteUpdated', _.bind(me.onSiteUpdated, me));
+
+    // listen for cache cleared
+    controller.sites.on('cacheCleared', _.bind(me.onCacheCleared, me));
 };
 
 util.inherits(exports.PhpFpmService, require('./abstract.js').AbstractService);
@@ -214,6 +217,32 @@ exports.PhpFpmService.prototype.onSiteUpdated = function(siteData) {
         uri: 'cache.php',
         json: [
             { action: 'delete', key: siteRoot }
+        ]
+    }, function(err, output, phpErrors) {
+        if (err == 99) console.error('PHPFPM server error');
+        console.log(output);
+        if (phpErrors) console.error(phpErrors);
+    });
+};
+
+exports.PhpFpmService.prototype.onCacheCleared = function(data) {
+    var me = this,
+        siteRoot = me.controller.sites.options.sitesDir + '/' + data.handle,
+        phpClient;
+
+    console.log(me.name+': clearing cache for '+siteRoot);
+
+    // Connect to FPM worker pool
+    phpClient = new phpfpm({
+        sockFile: me.options.socketPath,
+        documentRoot: me.options.bootstrapDir + '/'
+    });
+
+    // Clear cached site.json
+    phpClient.run({
+        uri: 'cache.php',
+        json: [
+            { action: data.action, key: data.key, site: data.handle }
         ]
     }, function(err, output, phpErrors) {
         if (err == 99) console.error('PHPFPM server error');

--- a/kernel-lib/sites.js
+++ b/kernel-lib/sites.js
@@ -203,6 +203,23 @@ exports.Sites.prototype.handleRequest = function(request, response, server) {
                     });
 
                     return true;
+
+                } else if (request.path[2] == 'cache') {
+
+                    requestData.handle = request.path[1];
+                    console.log('Executing cache post for ' + request.path[1] + ':');
+                    console.log(requestData);
+
+                    // Clear cache
+                    me.emit('cacheCleared', requestData);
+
+                    response.writeHead(200, {'Content-Type':'application/json'});
+                    response.end(JSON.stringify({
+                        success: true,
+                        message: 'cache cleared request finished',
+                    }));
+                    return true;
+
                 } else {
                     console.error('Unhandled site sub-resource: ' + request.path[2]);
                     response.writeHead(404, {'Content-Type':'application/json'});

--- a/php-bootstrap/cache.php
+++ b/php-bootstrap/cache.php
@@ -12,6 +12,7 @@ $commands = json_decode(file_get_contents('php://input'), true);
 
 foreach ($commands AS $command) {
     $key = $command['key'];
+    $action = $command['action'];
 
     if (!empty($command['site'])) {
         $key = $command['site'].':'.$key;
@@ -19,6 +20,12 @@ foreach ($commands AS $command) {
 
     if ($action == 'delete') {
         Cache::rawDelete($key);
+
+    } elseif ($action == 'delete-pattern') {
+        foreach (CacheIterator::createFromPattern($pattern) as $cacheEntry) {
+            Cache::rawDelete($cacheEntry['key']);
+        }
+
     } else {
         Cache::rawStore(
             $key,


### PR DESCRIPTION
The goal here is to enable cache clearing via a POST to the kernel. The use case is for Convergence which uses a php-shell command to run the pull tool / precache from a remote site. Without this endpoint, we aren't able to clear the efs cache which actually exposed what ever changes were just pulled in.