### PR TITLE
Release: emergence v1.0.8

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+**/node_modules
+.eslintrc.json
+.gitignore
+.npmignore
+cloud-config.yaml
+Dockerfile
+run-dev-container

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+.dockerignore
+.eslintrc.json
+.gitignore
+cloud-config.yaml
+Dockerfile
+run-dev-container

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,8 @@ RUN hab pkg install jarvus/sencha-cmd/5.1.3.61/20170606195324 jarvus/underscore 
 
 
 # install emergence
-RUN npm install -g emergence
+RUN npm install -g emergence \
+    && npm install -g htpasswd
 
 
 # setup and expose emergence

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && add-apt-repository ppa:certbot/certbot \
     && apt-get update \
     && apt-get install -y --allow-unauthenticated --no-install-recommends \
-        certbot \
+        certbot python3-pyasn1 \
         php-apcu \
         php5.6-cli \
         php5.6-curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN service nginx stop \
 
 # install Habitat client and packages for emergence
 RUN curl -s https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash
-RUN hab pkg install jarvus/sencha-cmd/5.1.3.61/20170606195324 jarvus/underscore \
+RUN hab pkg install jarvus/sencha-cmd/6.5.2.15 jarvus/underscore \
     && hab pkg binlink jarvus/sencha-cmd sencha \
     && hab pkg binlink jarvus/underscore underscore
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         tmux \
         vim \
     && add-apt-repository -y ppa:ondrej/php \
+    && add-apt-repository ppa:certbot/certbot \
     && apt-get update \
     && apt-get install -y --allow-unauthenticated --no-install-recommends \
+        certbot \
         php-apcu \
         php5.6-cli \
         php5.6-curl \

--- a/bin/certbot-auth
+++ b/bin/certbot-auth
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+log () {
+    echo "emergence-certbot-auth: $@"
+}
+
+die () {
+    echo >&2 "emergence-certbot-auth: $@"
+    exit 1
+}
+
+
+# check usage
+[ -n "${CERTBOT_DOMAIN}" ] || die "required environment variable missing: \$CERTBOT_DOMAIN"
+[ -n "${CERTBOT_VALIDATION}" ] || die "required environment variable missing: \$CERTBOT_VALIDATION"
+[ -n "${CERTBOT_TOKEN}" ] || die "required environment variable missing: \$CERTBOT_TOKEN"
+
+
+# determine location of this script
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+
+# resolve site handle for domain
+SITE_HANDLE="$(${DIR}/resolve-site ${CERTBOT_DOMAIN})"
+[ -n "${SITE_HANDLE}" ] || die "could not resolve domain '${CERTBOT_DOMAIN}' under /emergence/sites/*/site.json"
+
+
+# write auth file
+log "writing ${SITE_HANDLE}/${CERTBOT_TOKEN}"
+echo "${CERTBOT_VALIDATION}" | "${DIR}/write-file" "${SITE_HANDLE}" "site-root/.well-known/acme-challenge/${CERTBOT_TOKEN}" || die "failed to write token to VFS"

--- a/bin/certbot-cleanup
+++ b/bin/certbot-cleanup
@@ -12,9 +12,7 @@ die () {
 
 # check usage
 [ -n "${CERTBOT_DOMAIN}" ] || die "required environment variable missing: \$CERTBOT_DOMAIN"
-[ -n "${CERTBOT_VALIDATION}" ] || die "required environment variable missing: \$CERTBOT_VALIDATION"
 [ -n "${CERTBOT_TOKEN}" ] || die "required environment variable missing: \$CERTBOT_TOKEN"
-[ -n "${CERTBOT_AUTH_OUTPUT}" ] || die "required environment variable missing: \$CERTBOT_AUTH_OUTPUT"
 
 
 # determine location of this script

--- a/bin/certbot-cleanup
+++ b/bin/certbot-cleanup
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+log () {
+    echo "emergence-certbot-cleanup: $@"
+}
+
+die () {
+    echo >&2 "emergence-certbot-cleanup: $@"
+    exit 1
+}
+
+
+# check usage
+[ -n "${CERTBOT_DOMAIN}" ] || die "required environment variable missing: \$CERTBOT_DOMAIN"
+[ -n "${CERTBOT_VALIDATION}" ] || die "required environment variable missing: \$CERTBOT_VALIDATION"
+[ -n "${CERTBOT_TOKEN}" ] || die "required environment variable missing: \$CERTBOT_TOKEN"
+[ -n "${CERTBOT_AUTH_OUTPUT}" ] || die "required environment variable missing: \$CERTBOT_AUTH_OUTPUT"
+
+
+# determine location of this script
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+
+# resolve site handle for domain
+SITE_HANDLE="$(${DIR}/resolve-site ${CERTBOT_DOMAIN})"
+[ -n "${SITE_HANDLE}" ] || die "could not resolve domain '${CERTBOT_DOMAIN}' under /emergence/sites/*/site.json"
+
+
+# delete auth file
+log "deleting ${SITE_HANDLE}/${CERTBOT_TOKEN}"
+"${DIR}/delete-file" "${SITE_HANDLE}" "site-root/.well-known/acme-challenge/${CERTBOT_TOKEN}" || die "failed to delete token from VFS"

--- a/bin/delete-file
+++ b/bin/delete-file
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+die () {
+    echo >&2 "$@"
+    exit 1
+}
+
+
+# check usage
+[ -n "$1" ] && [ -n "$2" ] || die "Usage: emergence-delete-file <site-handle> <site-file-path>"
+
+
+# determine location of this script
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+
+# execute php script
+cat <<'END_OF_PHP' | "${DIR}/shell" "$1" --stdin "$2"
+<?php
+
+$node = Site::resolvePath($argv[1]);
+
+if (!$node) {
+    error_log('emergence-delete-file: cannot remove \''.$argv[1].'\': No such file');
+    exit(1);
+}
+
+try {
+    $node->delete();
+    exit(0);
+} catch (Exception $e) {
+    error_log('emergence-delete-file: failed to delete file from VFS: '.$e->getMessage());
+    exit(1);
+}
+
+END_OF_PHP
+
+

--- a/bin/read-file
+++ b/bin/read-file
@@ -27,7 +27,8 @@ cat <<'END_OF_PHP' | "${DIR}/shell" "$1" --stdin "$2"
 $node = Site::resolvePath($argv[1]);
 
 if (!$node) {
-    exit(6);
+    error_log('emergence-read-file: cannot read \''.$argv[1].'\': No such file');
+    exit(1);
 }
 
 readfile($node->RealPath);

--- a/bin/read-file
+++ b/bin/read-file
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+die () {
+    echo >&2 "$@"
+    exit 1
+}
+
+
+# check usage
+[ -n "$1" ] && [ -n "$2" ] || die "Usage: emergence-read-file <site-handle> <site-file-path>"
+
+
+# determine location of this script
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+
+# execute php script
+cat <<'END_OF_PHP' | "${DIR}/shell" "$1" --stdin "$2"
+<?php
+
+$node = Site::resolvePath($argv[1]);
+
+if (!$node) {
+    exit(6);
+}
+
+readfile($node->RealPath);
+exit(0);
+
+END_OF_PHP
+
+

--- a/bin/resolve-site
+++ b/bin/resolve-site
@@ -1,13 +1,14 @@
 #!/bin/bash
 
 die () {
-    echo >&2 "$@"
+    echo >&2 "emergence-resolve-site: $@"
     exit 1
 }
 
 
 # check usage
 [ -n "$1" ] || die "Usage: emergence-resolve-site <hostname>"
+[ -d "/emergence/sites" ] || die "/emergence/sites not found"
 
 
 # determine location of this script

--- a/bin/resolve-site
+++ b/bin/resolve-site
@@ -28,7 +28,7 @@ UNDERSCORE="$DIR/../node_modules/.bin/underscore"
 pushd /emergence/sites > /dev/null
 for SITE_DIR in `find . -maxdepth 1 ! -path . -type d`; do
     SITE_HANDLE="$(basename ${SITE_DIR})"
-    SITE_HOSTNAMES="$(sudo cat /emergence/sites/test/site.json | $UNDERSCORE process '(data.hostnames||[]).concat([data.primary_hostname]).filter(x=>x)' --outfmt text)"
+    SITE_HOSTNAMES="$(sudo cat ${SITE_DIR}/site.json | $UNDERSCORE process '(data.hostnames||[]).concat([data.primary_hostname]).filter(x=>x)' --outfmt text)"
 
     for SITE_HOSTNAME in $SITE_HOSTNAMES; do
         if [[ "${1}" == $SITE_HOSTNAME ]]; then # NOT MATCHING WILDCARD

--- a/bin/resolve-site
+++ b/bin/resolve-site
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+die () {
+    echo >&2 "$@"
+    exit 1
+}
+
+
+# check usage
+[ -n "$1" ] || die "Usage: emergence-resolve-site <hostname>"
+
+
+# determine location of this script
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+
+# determine path to underscore
+UNDERSCORE="$DIR/../node_modules/.bin/underscore"
+
+
+# search sites
+pushd /emergence/sites > /dev/null
+for SITE_DIR in `find . -maxdepth 1 ! -path . -type d`; do
+    SITE_HANDLE="$(basename ${SITE_DIR})"
+    SITE_HOSTNAMES="$(sudo cat /emergence/sites/test/site.json | $UNDERSCORE process '(data.hostnames||[]).concat([data.primary_hostname]).filter(x=>x)' --outfmt text)"
+
+    for SITE_HOSTNAME in $SITE_HOSTNAMES; do
+        if [[ "${1}" == $SITE_HOSTNAME ]]; then # NOT MATCHING WILDCARD
+            echo "${SITE_HANDLE}"
+            exit 0
+        fi
+    done
+done
+popd > /dev/null
+
+
+# return failure if no match found
+exit 1

--- a/bin/shell
+++ b/bin/shell
@@ -57,6 +57,10 @@ fi
 
 # execute interactive shell
 TERM=$TERM sudo -E -u www-data -g www-data php -d auto_prepend_file=$autoPrependScript -d apc.enable_cli=on -d memory_limit=-1 $INPUT_ARGS
+SCRIPT_STATUS=$?
 
 # clean up
 rm $autoPrependScript;
+
+# relay exit status of php script
+exit $SCRIPT_STATUS

--- a/bin/write-file
+++ b/bin/write-file
@@ -7,7 +7,7 @@ die () {
 
 
 # check usage
-[ -n "$1" ] && [ -n "$2" ] || die "Usage: emergence-read-file <site-handle> <site-file-path> [host-file-path]"
+[ -n "$1" ] && [ -n "$2" ] || die "Usage: emergence-write-file <site-handle> <site-file-path> [host-file-path]"
 
 
 # determine location of this script
@@ -49,7 +49,7 @@ try {
     Emergence_FS::importFile($argv[2], $argv[1]);
     exit(0);
 } catch (Exception $e) {
-    error_log('Failed to import file into VFS: '.$e->getMessage());
+    error_log('emergence-write-file: failed to delete file from VFS: '.$e->getMessage());
     exit(1);
 }
 

--- a/bin/write-file
+++ b/bin/write-file
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+die () {
+    echo >&2 "$@"
+    exit 1
+}
+
+
+# check usage
+[ -n "$1" ] && [ -n "$2" ] || die "Usage: emergence-read-file <site-handle> <site-file-path> [host-file-path]"
+
+
+# determine location of this script
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+
+
+
+# read stdin to tmp
+if [ -z "${3}" ]; then
+    # determine path to underscore
+    UNDERSCORE="$DIR/../node_modules/.bin/underscore"
+
+    # read application group name
+    APP_GROUP="$(sudo cat /emergence/config.json | $UNDERSCORE extract --outfmt text group)"
+    INPUT_FILE="$(mktemp)"
+    chgrp "${APP_GROUP}" "${INPUT_FILE}"
+    chmod g+r "${INPUT_FILE}"
+
+    cat - > "${INPUT_FILE}"
+elif [ ! -f "${3}" ]; then
+    die "Input file ${3} not found"
+else
+    INPUT_FILE="${3}"
+fi
+
+
+# execute php script
+cat <<'END_OF_PHP' | exec "${DIR}/shell" "${1}" --stdin "${2}" "${INPUT_FILE}"
+<?php
+
+try {
+    Emergence_FS::importFile($argv[2], $argv[1]);
+    exit(0);
+} catch (Exception $e) {
+    error_log('Failed to import file into VFS: '.$e->getMessage());
+    exit(1);
+}
+
+END_OF_PHP
+
+

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "emergence-su": "./bin/su",
     "emergence-create-site": "./bin/create-site.sh",
     "emergence-mysql-shell": "./bin/mysql-shell",
-    "emergence-fire-event": "./bin/fire-event"
+    "emergence-fire-event": "./bin/fire-event",
+    "emergence-read-file": "./bin/read-file"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "emergence-create-site": "./bin/create-site.sh",
     "emergence-mysql-shell": "./bin/mysql-shell",
     "emergence-fire-event": "./bin/fire-event",
-    "emergence-read-file": "./bin/read-file"
+    "emergence-read-file": "./bin/read-file",
+    "emergence-write-file": "./bin/write-file"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emergence",
   "preferGlobal": true,
-  "version": "1.0.7",
+  "version": "1.0.8",
   "license": "MIT",
   "dependencies": {
     "hostile": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "emergence-fire-event": "./bin/fire-event",
     "emergence-read-file": "./bin/read-file",
     "emergence-write-file": "./bin/write-file",
+    "emergence-delete-file": "./bin/delete-file",
     "emergence-resolve-site": "./bin/resolve-site"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "emergence-read-file": "./bin/read-file",
     "emergence-write-file": "./bin/write-file",
     "emergence-delete-file": "./bin/delete-file",
-    "emergence-resolve-site": "./bin/resolve-site"
+    "emergence-resolve-site": "./bin/resolve-site",
+    "emergence-certbot-auth": "./bin/certbot-auth",
+    "emergence-certbot-cleanup": "./bin/certbot-cleanup"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "emergence-mysql-shell": "./bin/mysql-shell",
     "emergence-fire-event": "./bin/fire-event",
     "emergence-read-file": "./bin/read-file",
-    "emergence-write-file": "./bin/write-file"
+    "emergence-write-file": "./bin/write-file",
+    "emergence-resolve-site": "./bin/resolve-site"
   },
   "repository": {
     "type": "git",

--- a/php-bootstrap/lib/HttpProxy.class.php
+++ b/php-bootstrap/lib/HttpProxy.class.php
@@ -62,7 +62,7 @@ class HttpProxy
         }
 
         // get cookies
-        if (!isset($options['cookies'])) {
+        if (!isset($options['cookies']) && !empty($_SERVER['HTTP_COOKIE'])) {
             $options['cookies'] = $_SERVER['HTTP_COOKIE'];
         }
 


### PR DESCRIPTION
- support: **dropping support for legacy environments, assuming docker deployment**
- fix: avoid potentially undefined key in CLI
- feat: install htpasswd command
- chore: bump installed cmd version to 6.5.2.15
- chore: clean up route bypass end debugging code (backported from v1.1.0)
- refactor: build docker image with local kernel sources, bump all node packages to latest, and tweak .dockerignore / .npmignore lists (backported from v1.1.0)
- feat: pass through PHP shell script exit status (backported from v1.1.0)
- feat: add emergence-read-file shell command (backported from v1.1.0)
- feat: add emergence-write-file shell command (backported from v1.1.0)
- feat: add emergence-delete-file shell command (backported from v1.1.0)
- feat: add emergence-resolve-site shell command (backported from v1.1.0)
- feat: add certbot to docker image (backported from v1.1.0)
- feat: add certbot-auth and certbot-cleanup shell commands (backported from v1.1.0)
- chore: add .dockerignore and .npmignore files (backported from v1.1.0)